### PR TITLE
selectFragment

### DIFF
--- a/addon/globalPlugins/customNotifications/__init__.py
+++ b/addon/globalPlugins/customNotifications/__init__.py
@@ -30,6 +30,7 @@ _: Callable[[str], str]
 
 confspec: Dict[str, str] = {
 	"truncateNotifications": "boolean(default=True)",
+	"startLimit": 'string(default="")',
 	"endLimit": 'string(default=", ")',
 	"speech": "boolean(default=True)",
 	"braille": "boolean(default=True)",
@@ -122,9 +123,13 @@ class EnhancedNotification(Notification):
 		if not config.conf["presentation"]["reportHelpBalloons"]:
 			return
 		truncateNotifications = config.conf["customNotifications"]["truncateNotifications"]
+		startLimit = config.conf["customNotifications"]["startLimit"]
 		endLimit = config.conf["customNotifications"]["endLimit"]
-		if truncateNotifications and endLimit:
-			self.name = self.name.split(endLimit)[0]
+		if truncateNotifications:
+			if startLimit:
+				self.name = self.name.split(startLimit, 1)[1]
+			if endLimit:
+				self.name = self.name.split(endLimit)[0]
 		if config.conf["customNotifications"]["speech"]:
 			speech.speakObject(self, reason=controlTypes.OutputReason.FOCUS)
 		# Ideally, we wouldn't use getPropertiesBraille directly.

--- a/addon/globalPlugins/customNotifications/gui.py
+++ b/addon/globalPlugins/customNotifications/gui.py
@@ -8,7 +8,8 @@ from typing import Callable
 
 import config
 import gui
-from gui import SettingsPanel, guiHelper
+from gui import guiHelper
+from gui.settingsDialogs import SettingsPanel
 import addonHandler
 
 addonHandler.initTranslation()

--- a/addon/globalPlugins/customNotifications/gui.py
+++ b/addon/globalPlugins/customNotifications/gui.py
@@ -27,6 +27,10 @@ class AddonSettingsPanel(SettingsPanel):
 		# Translators: label of a dialog.
 		self.truncateNotificationsCheckBox = sHelper.addItem(wx.CheckBox(self, label=_("&Truncate notifications")))
 		self.truncateNotificationsCheckBox.SetValue(config.conf["customNotifications"]["truncateNotifications"])
+				# Translators: label of a dialog.
+		startLimitLabel = _("Type the characters to be used as the &start limit of notifications")
+		self.startLimitEdit = sHelper.addLabeledControl(startLimitLabel, wx.TextCtrl)
+		self.startLimitEdit.SetValue(config.conf["customNotifications"]["startLimit"])
 		# Translators: label of a dialog.
 		endLimitLabel = _("Type the characters to be used as the end &limit of notifications")
 		self.endLimitEdit = sHelper.addLabeledControl(endLimitLabel, wx.TextCtrl)
@@ -68,6 +72,7 @@ class AddonSettingsPanel(SettingsPanel):
 
 	def onSave(self):
 		config.conf["customNotifications"]["truncateNotifications"] = self.truncateNotificationsCheckBox.GetValue()
+		config.conf["customNotifications"]["startLimit"] = self.startLimitEdit.GetValue()
 		config.conf["customNotifications"]["endLimit"] = self.endLimitEdit.GetValue()
 		config.conf["customNotifications"]["speech"] = self.outputModesList.IsChecked(0)
 		config.conf["customNotifications"]["braille"] = self.outputModesList.IsChecked(1)

--- a/addon/globalPlugins/customNotifications/gui.py
+++ b/addon/globalPlugins/customNotifications/gui.py
@@ -28,7 +28,7 @@ class AddonSettingsPanel(SettingsPanel):
 		# Translators: label of a dialog.
 		self.truncateNotificationsCheckBox = sHelper.addItem(wx.CheckBox(self, label=_("&Truncate notifications")))
 		self.truncateNotificationsCheckBox.SetValue(config.conf["customNotifications"]["truncateNotifications"])
-				# Translators: label of a dialog.
+		# Translators: label of a dialog.
 		startLimitLabel = _("Type the characters to be used as the &start limit of notifications")
 		self.startLimitEdit = sHelper.addLabeledControl(startLimitLabel, wx.TextCtrl)
 		self.startLimitEdit.SetValue(config.conf["customNotifications"]["startLimit"])

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,7 @@ You can choose to read the whole notification or just the application which send
 Go to NVDA's menu, Preferences submenu, Settings, and select the Custom Notifications category. There you'll find the following controls:
 
 * A checkbox to choose if notifications should be truncated, checked by default.
+* An edit box to set the start limit of notifications, empty by default.
 * An edit box to set the end limit of notifications, ", " (comma space) by default.
 * A list of checkboxes to select if notifications should be spoken and displayed in braille, both checked by default.
 * An edit box to type a text to send a test notification, to get an idea of how NVDA will present toasts.


### PR DESCRIPTION
- Add support for start limit in notifications
- Improve import for SettingsPanel

<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:
Some people may want to receive the main content of notifications instead of the originating app.
Requested by Libardo.
### Description of how this pull request fixes the issue:
A startLimit parameter, similar to endLimit, has been added.
### Testing performed:
Tested locally.
### Known issues with pull request:
None
### Change log entry:
* Added ability to set a start limit for notifications.